### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -51,7 +51,7 @@ class syntax_plugin_yearbox extends DokuWiki_Syntax_Plugin {
      * E.g.: {{yearbox>year=2010;name=journal;size=12;ns=diary}}
      *
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         global $INFO;
         $opt = array();
 
@@ -105,7 +105,7 @@ class syntax_plugin_yearbox extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $opt) {
+    function render($mode, Doku_Renderer $renderer, $opt) {
         if ($mode == 'xhtml') {
             $renderer->doc .= $this->build_calendar($opt);
             return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
